### PR TITLE
Make linter enforce arrow functions

### DIFF
--- a/src/world.ts
+++ b/src/world.ts
@@ -45,9 +45,8 @@ export class World {
   }*/
 
   // Render world:
-  render = function () {
+  render = () => {
     requestAnimationFrame( this.render );
     this.renderer.render(this.scene, this.camera);
-  };
-
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "trailing-comma": [true, { "multiline": "always", "singleline": "never" }],
     "object-curly-spacing": [true, "always"],
     "dot-notation": false,
-    "no-shadowed-variable": false
+    "no-shadowed-variable": false,
+    "only-arrow-functions": [true, "allow-declarations"]
   }
 }


### PR DESCRIPTION
This prevents us from using the `function` keyword for anonymous functions because arrow functions are syntactically nicer and behave better with regards to the scope of `this`.