### PR TITLE
Add Keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Project Papa Client
 
-###
+## Controls
+
+You can click and drag with the mouse to immitate moving the headset.
+
+You can use the keyboard to immitate the Myo. You can see the mappings from keys to gestures [here](src/controls/keyboard.ts).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@types/three": "^0.83.1",
     "html-webpack-plugin": "^2.28.0",
     "jest": "^18.1.0",
+    "keyboardevent-key-polyfill": "^1.0.2",
+    "rxjs": "^5.2.0",
     "testdouble": "^1.11.1",
     "three": "^0.84.0",
     "three-vreffect": "^1.0.0",

--- a/src/controls/controller.ts
+++ b/src/controls/controller.ts
@@ -1,0 +1,64 @@
+import { polyfill as keyEventPolyfill } from 'keyboardevent-key-polyfill';
+import { Observable } from 'rxjs';
+
+keyEventPolyfill();
+
+type EventName = 'fist' | 'spread' | 'double-tap' | 'wave-in' | 'wave-out';
+
+interface PoseEvent<T extends EventName> {
+  type: T;
+  observe(): Observable<any>;
+}
+
+export interface FistEvent extends PoseEvent<'fist'> { }
+
+export interface SpreadEvent extends PoseEvent<'spread'> { }
+
+export interface DoubleTapEvent extends PoseEvent<'double-tap'> { }
+
+export interface WaveInEvent extends PoseEvent<'wave-in'> { }
+
+export interface WaveOutEvent extends PoseEvent<'wave-out'> { }
+
+export type ControlEvent = PoseEvent<EventName>;
+
+export type EventStream = Observable<PoseEvent<EventName>>;
+
+export const eventIs = {
+  fist(event: ControlEvent): event is FistEvent {
+    return event.type === 'fist';
+  },
+  spread(event: ControlEvent): event is SpreadEvent {
+    return event.type === 'spread';
+  },
+  doubleTap(event: ControlEvent): event is DoubleTapEvent {
+    return event.type === 'double-tap';
+  },
+  waveIn(event: ControlEvent): event is WaveInEvent {
+    return event.type === 'wave-in';
+  },
+  waveOut(event: ControlEvent): event is WaveOutEvent {
+    return event.type === 'wave-out';
+  },
+};
+
+type PoseListener = {
+  start(): void,
+  finish?(): void,
+};
+
+/**
+ * Returns a function that you can use as a subscriber to listen for starts and stops
+ * of poses
+ */
+export function listenPose({ start, finish }: PoseListener) {
+  return (event: ControlEvent) => {
+    start();
+
+    if (finish) {
+      event.observe().subscribe({
+        complete() { finish(); },
+      });
+    }
+  };
+}

--- a/src/controls/document-keyboard-events.ts
+++ b/src/controls/document-keyboard-events.ts
@@ -1,0 +1,23 @@
+import { polyfill } from 'keyboardevent-key-polyfill';
+import { Observable } from 'rxjs';
+polyfill();
+
+export interface KeyDown {
+  type: 'down';
+  key: string;
+}
+
+export interface KeyUp {
+  type: 'up';
+  key: string;
+}
+
+export function getDownKeys(element: Node) {
+  return Observable.fromEvent<KeyboardEvent>(element, 'keydown')
+    .map<KeyboardEvent, KeyDown>(event => ({ type: 'down', key: event.key }));
+}
+
+export function getUpKeys(element: Node) {
+  return Observable.fromEvent<KeyboardEvent>(element, 'keyup')
+    .map<KeyboardEvent, KeyUp>(event => ({ type: 'up', key: event.key }));
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -1,0 +1,9 @@
+import { Observable } from 'rxjs';
+import { EventStream } from './controller';
+import { default as streamKeyboardFromElement } from './keyboard';
+
+export const controlEvents: EventStream = Observable.merge(
+  streamKeyboardFromElement(document).share(),
+);
+
+export * from './controller';

--- a/src/controls/keyboard.ts
+++ b/src/controls/keyboard.ts
@@ -1,0 +1,58 @@
+import { Observable } from 'rxjs';
+import * as controller from './controller';
+import { KeyUp, KeyDown, getDownKeys, getUpKeys } from './document-keyboard-events';
+
+function keyboardEvents(element: Node) {
+  return Observable.merge(
+    getDownKeys(element),
+    getUpKeys(element),
+  );
+}
+
+function createStreamForKey<T extends controller.ControlEvent>(key: string, constructor: (onComplete: Observable<any>) => T, keyEvents: Observable<KeyDown | KeyUp>) {
+  const keyStream = keyEvents
+    .filter(event => event.key === key)
+    .distinctUntilChanged((event1, event2) => event1.type === event2.type);
+
+  return keyStream
+    .filter(event => event.type === 'down')
+    .map(event => {
+      const finished = keyStream.filter(event => event.type === 'up')
+        .first()
+        .ignoreElements();
+
+      return constructor(finished);
+    });
+}
+
+export default function streamFromElement(element: Node): controller.EventStream {
+  const keyEvents = keyboardEvents(element);
+
+  return Observable.merge(
+    createStreamForKey<controller.FistEvent>(
+      'q',
+      onComplete => ({ type: 'fist', observe: () => onComplete }),
+      keyEvents,
+    ),
+    createStreamForKey<controller.DoubleTapEvent>(
+      'w',
+      onComplete => ({ type: 'double-tap', observe: () => onComplete }),
+      keyEvents,
+    ),
+    createStreamForKey<controller.SpreadEvent>(
+      'e',
+      onComplete => ({ type: 'spread', observe: () => onComplete }),
+      keyEvents,
+    ),
+    createStreamForKey<controller.WaveInEvent>(
+      'r',
+      onComplete => ({ type: 'wave-in', observe: () => onComplete }),
+      keyEvents,
+    ),
+    createStreamForKey<controller.WaveOutEvent>(
+      't',
+      onComplete => ({ type: 'wave-out', observe: () => onComplete }),
+      keyEvents,
+    ),
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,12 @@
-import { add } from 'src/lib';
+import * as controls from './controls';
 import { World } from './world';
+
+// Using the control events
+controls.controlEvents
+  .filter(controls.eventIs.doubleTap)
+  .subscribe(controls.listenPose({
+    start() { console.log('We start'); },
+    finish() { console.log('We finish'); },
+  }));
 
 (new World()).start();

--- a/src/vendor/vendor.d.ts
+++ b/src/vendor/vendor.d.ts
@@ -1,0 +1,3 @@
+declare module 'keyboardevent-key-polyfill' {
+  export function polyfill();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,6 +2232,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+keyboardevent-key-polyfill:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.0.2.tgz#3b58c8bbdef2d92212cb3ee0af59091425354473"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -3284,6 +3288,12 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
+rxjs:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 sane@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.4.1.tgz#88f763d74040f5f0c256b6163db399bf110ac715"
@@ -3580,6 +3590,10 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 "symbol-tree@>= 3.1.0 < 4.0.0":
   version "3.2.1"


### PR DESCRIPTION
This PR makes it possible to listen to gesture events. Currently, it is only possible to operate these with the keyboard (instructions are in the readme).

An example of how to use it is present in `main.ts`, logging the start and end of a gesture. I imagine that'll be nuked when someone actually uses this thing.