### PR TITLE
Add listening capabilities to Sonic Pi Communicator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as controls from './controls';
 import { World } from './world';
+import SonicPiCommunicator from 'src/pi/SonicPiCommunicator';
 
 // Using the control events
 controls.controlEvents

--- a/src/pi/__tests__/SmartWebSocket.ts
+++ b/src/pi/__tests__/SmartWebSocket.ts
@@ -18,8 +18,8 @@ it('queues messages while waiting to connect', () => {
   const socket: any = td.object(['send', 'addEventListener']);
   socket.readyState = WebSocket.CONNECTING;
 
-  let smartSocket: SmartWebSocket;
-  let openCallback: Function = () => 0;
+  let smartSocket: SmartWebSocket<any>;
+  let openCallback: Function | undefined;
 
   td.when(socket.addEventListener('open', td.matchers.isA(Function)))
     .thenDo((eventType: string, callback: Function) => {
@@ -32,6 +32,11 @@ it('queues messages while waiting to connect', () => {
   td.verify(socket.send(td.matchers.anything()), { times: 0 });
 
   socket.readyState = WebSocket.OPEN;
+
+  if (!openCallback) {
+    throw new Error('No listener created for socket open');
+  }
+
   openCallback();
 
   // We wrap the verification in a promise as there is some asynchronisity to account for
@@ -39,4 +44,34 @@ it('queues messages while waiting to connect', () => {
     .then(() =>
       td.verify(socket.send(JSON.stringify({ foo: 'bar' }))),
     );
+});
+
+it('observe() forwards websocket messages', () => {
+  const socket: any = td.object(['addEventListener']);
+  socket.readyState = WebSocket.OPEN;
+
+  let smartSocket: SmartWebSocket<any>;
+  let sendCallback: Function | undefined;
+
+  td.when(socket.addEventListener('message', td.matchers.isA(Function)))
+    .thenDo((eventType: string, callback: Function) => {
+      sendCallback = callback;
+    });
+
+  smartSocket = new SmartWebSocket(socket);
+
+  const messages: any[] = [];
+  const subscription = smartSocket
+    .observe()
+    .subscribe(message => messages.push(message));
+
+  if (!sendCallback) {
+    throw new Error('No listener created for socket');
+  }
+
+  sendCallback({ data: JSON.stringify({ foo: 'bar' }) });
+
+  expect(messages).toEqual([{ foo: 'bar' }]);
+
+  subscription.unsubscribe();
 });

--- a/src/pi/__tests__/SonicPiCommunicator.ts
+++ b/src/pi/__tests__/SonicPiCommunicator.ts
@@ -1,9 +1,24 @@
 jest.mock('../WebSocket');
 
 import * as td from 'testdouble';
+import { Observable } from 'rxjs';
 
 import SonicPiCommunicator from '../SonicPiCommunicator';
 import WebSocket from '../WebSocket';
+
+const mockSonicPiMessage = {
+  type: 'sonic-pi',
+  message: {
+    messageType: 'foo',
+  },
+};
+
+const mockOscMessage = {
+  type: 'osc',
+  oscData: [],
+};
+
+const mockOutput = Observable.from([mockSonicPiMessage, mockOscMessage]);
 
 it('should stop all jobs when called', () => {
   const socket: any = td.object(['send']);
@@ -24,4 +39,40 @@ it('should run code when called', () => {
     command: 'run-code',
     code: 'print "hello"',
   }));
+});
+
+it('should pass emissions from websocket', async () => {
+  const socket: any = td.object(['observe']);
+  const communicator = new SonicPiCommunicator(socket);
+  td.when(socket.observe()).thenReturn(mockOutput);
+
+  const result = await communicator.observe().toArray().toPromise();
+
+  expect(result).toEqual(
+    [mockSonicPiMessage, mockOscMessage],
+  );
+});
+
+it('should filter sonic pi messages correctly', async () => {
+  const socket: any = td.object(['observe']);
+  const communicator = new SonicPiCommunicator(socket);
+  td.when(socket.observe()).thenReturn(mockOutput);
+
+  const result = await communicator.sonicPiMessages().toArray().toPromise();
+
+  expect(result).toEqual(
+    [mockSonicPiMessage],
+  );
+});
+
+it('should filter oscilloscope messages correctly', async () => {
+  const socket: any = td.object(['observe']);
+  const communicator = new SonicPiCommunicator(socket);
+  td.when(socket.observe()).thenReturn(mockOutput);
+
+  const result = await communicator.oscData().toArray().toPromise();
+
+  expect(result).toEqual(
+    [mockOscMessage],
+  );
 });


### PR DESCRIPTION
This PR forwards data sent from Sonic Pi to the communicator. Tests have been added to make sure that this works.

Our server currently does not send messages in this format (but will do in the future), so this change does not work yet.
