### PR TITLE
Add API for listening to LiveLoop oscilloscope data

### DIFF
--- a/src/generation/Coordinator.ts
+++ b/src/generation/Coordinator.ts
@@ -2,6 +2,8 @@ import LiveLoop from './LiveLoop';
 import Effect from './Effect';
 import SonicPiCommunicator from '../pi/SonicPiCommunicator';
 
+const GLOBAL_OSCILLOSCOPE_INDEX = 1;
+
 export default class Coordinator {
 
   private header: string = '';
@@ -18,11 +20,12 @@ export default class Coordinator {
   private deadLoops = new Set<LiveLoop>();
 
   public constructor() {
-
     // Add the free scope numbers
     for(let i = 2; i < 128; i++) {
-      this.freeScopeNums[i] = i;
+      this.freeScopeNums.push(i);
     }
+
+    console.log(this.freeScopeNums);
 
     // Define the header timing information
     this.header =
@@ -112,8 +115,11 @@ export default class Coordinator {
     }
 
     // Add global scope number 1
-    this.outputRuby = 'with_fx \"sonic-pi-fx_scope_out\", scope_num: 1 do\n'
-                      + this.outputRuby + '\nend\n';
+    this.outputRuby = `
+      with_fx "sonic-pi-fx_scope_out", scope_num: ${GLOBAL_OSCILLOSCOPE_INDEX} do
+        ${this.outputRuby}
+      end
+    `;
 
     // Stop all killed loops
     if (this.deadLoops.size !== 0) {
@@ -128,7 +134,18 @@ export default class Coordinator {
       this.deadLoops = new Set<LiveLoop>();
     }
 
+    console.log(this.outputRuby);
+
     this.communicator.runCode(this.outputRuby);
   }
 
+  public oscilloscopeDataForIndex(scopeNum: number) {
+    return this.communicator
+      .oscData()
+      .map(oscData => oscData.oscData[scopeNum]);
+  }
+
+  public globalOscilloscopeData() {
+    return this.oscilloscopeDataForIndex(GLOBAL_OSCILLOSCOPE_INDEX);
+  }
 }

--- a/src/generation/LiveLoop.ts
+++ b/src/generation/LiveLoop.ts
@@ -139,4 +139,22 @@ export default class LiveLoop {
     LiveLoop.coordinator.removeLoopFromSet(this);
   }
 
+  oscilloscopeData() {
+    return LiveLoop.coordinator.oscilloscopeDataForIndex(this.scopeNum);
+  }
+
+  static globalOscilloscopeData() {
+    return this.coordinator.globalOscilloscopeData();
+  }
+}
+
+/**
+ * Example of subscribing to a live loop
+ */
+function subscribeToLiveLoop() {
+  (new LiveLoop('weird_vinyl')).oscilloscopeData().subscribe(
+    number => {
+      console.log(number);
+    },
+  );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import * as controls from './controls';
 import { World } from './world';
-import SonicPiCommunicator from 'src/pi/SonicPiCommunicator';
 
 // Using the control events
 controls.controlEvents

--- a/src/pi/SmartWebSocket.ts
+++ b/src/pi/SmartWebSocket.ts
@@ -40,7 +40,7 @@ export default class SmartWebSocket<T> {
 
   constructor(websocket: WebSocket) {
     this.websocket = websocket;
-    this.observable = websocketToObservable<T>(this.websocket);
+    this.observable = websocketToObservable<T>(this.websocket).share();
     awaitWebsocketReady(this.websocket)
       .then(() => this.flushMessageQueue());
   }

--- a/src/pi/SonicPiCommunicator.ts
+++ b/src/pi/SonicPiCommunicator.ts
@@ -12,7 +12,7 @@ interface SonicPiMessage {
 
 interface OscilloscopeMessage {
   type: 'osc';
-  oscData: any;
+  oscData: number[];
 }
 
 type CommunicatorMessage = SonicPiMessage | OscilloscopeMessage;


### PR DESCRIPTION
This adds an API so you can listen to oscilloscope data as it happens on our server. No verification done, because our server doesn't yet give us this data.