### PR TITLE
Add SelectListener to listen for look ats

### DIFF
--- a/src/SelectListener.ts
+++ b/src/SelectListener.ts
@@ -1,0 +1,59 @@
+import THREE = require('three');
+import { Subject } from 'rxjs';
+import { Selector } from 'src/selector';
+
+interface SelectionEvent {
+  selected: true;
+}
+
+interface DeselectionEvent {
+  selected: false;
+}
+
+type SelectListenerEvent = SelectionEvent | DeselectionEvent;
+
+/**
+ * Listens for selection of meshes activated by the camera looking at a mesh.
+ */
+export default class SelectListener {
+  selector: Selector;
+  meshesToSubjects: WeakMap<THREE.Mesh, Subject<SelectListenerEvent>> = new WeakMap();
+
+  constructor(camera: THREE.Camera, scene: THREE.Scene) {
+    this.selector = new Selector(
+      camera,
+      scene,
+      mesh => this.onSelect(mesh),
+      mesh => this.onDeselect(mesh),
+      () => undefined,
+    );
+  }
+
+  observeSelections(mesh: THREE.Mesh) {
+    return this.getMeshSubject(mesh).asObservable();
+  }
+
+  getMeshSubject(mesh: THREE.Mesh) {
+    if (!this.meshesToSubjects.has(mesh)) {
+      this.meshesToSubjects.set(mesh, new Subject());
+    }
+
+    return this.meshesToSubjects.get(mesh)!;
+  }
+
+  onSelect(mesh: THREE.Mesh) {
+    this.getMeshSubject(mesh).next({
+      selected: true,
+    });
+  }
+
+  onDeselect(mesh: THREE.Mesh) {
+    this.getMeshSubject(mesh).next({
+      selected: false,
+    });
+  }
+
+  update() {
+    this.selector.updateSelectedMesh();
+  }
+}

--- a/src/entities/LiveLoopTemplate.ts
+++ b/src/entities/LiveLoopTemplate.ts
@@ -1,5 +1,7 @@
 import { Entity } from './entity';
 import { World } from 'src/world';
+import { Subscription } from 'rxjs';
+import { controlEvents, eventIs } from 'src/controls';
 import THREE = require('three');
 import { LiveLoopName } from 'src/generation/directory';
 
@@ -27,6 +29,8 @@ const liveLoopMaterial = new THREE.MeshPhongMaterial({
  */
 export default class LiveLoopTemplate implements Entity {
   mesh: THREE.Mesh;
+  subscription: Subscription;
+  selected: boolean = false;
 
   constructor(definition: LiveLoopTemplateDefinition) {
     this.mesh = new THREE.Mesh(
@@ -43,10 +47,26 @@ export default class LiveLoopTemplate implements Entity {
 
   onAdd(world: World) {
     world.scene.add(this.mesh);
+    this.subscription = new Subscription();
+    this.subscription.add(
+      world.selectListener
+        .observeSelections(this.mesh)
+        .subscribe(event => this.selected = event.selected),
+    );
+    this.subscription.add(
+      controlEvents
+        .filter(eventIs.fist)
+        .subscribe(event => {
+          if (this.selected) {
+            console.log('FIST ON ME!');
+          }
+        }),
+    );
   }
 
   onRemove(world: World) {
     world.scene.remove(this.mesh);
+    this.subscription.unsubscribe();
   }
 }
 

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -21,7 +21,7 @@ export class Selector {
    * Constructor takes a camera to set up raytracer
    * and scene from which meshes can be selected
    */
-  constructor(camera : THREE.PerspectiveCamera,
+  constructor(camera : THREE.Camera,
                 scene : THREE.Scene,
                 onMeshSelected : (mesh : THREE.Mesh) => void,
                 onMeshDeselected : (mesh : THREE.Mesh) => void,

--- a/src/world.ts
+++ b/src/world.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 
 import { Colours } from 'src/colours';
 import { Shape, Sphere, Torus, Icosahedron, Cylinder, Box, Tetrahedron, Octahedron, Dodecahedron, LiveLoopShape } from 'src/shape';
-import { Selector } from 'src/selector';
+import SelectListener from 'src/SelectListener';
 import { Entity } from 'src/entities/entity';
 import LiveLoopTemplate, { templateDefinitions } from 'src/entities/LiveLoopTemplate';
 import { LiveLoopName, EffectName } from './generation/directory';
@@ -36,7 +36,7 @@ export class World {
    */
   private lights: Array<THREE.Light> = [];
 
-  private shapeSelector: Selector;
+  readonly selectListener: SelectListener;
 
   constructor() {
     // Basic set up of scene, camera, and renderer:
@@ -59,24 +59,7 @@ export class World {
     this.vrEnvironment.setSize(window.innerWidth, window.innerHeight);
 
     // Set up the Selector by passing it the scene and camera
-    this.shapeSelector = new Selector(
-      this.camera,
-      this.scene,
-      (mesh: THREE.Mesh) => { /* On mesh selection */
-        // TEMPORARY - For demonstration purposes
-        if ((mesh as THREE.Mesh).geometry instanceof THREE.BoxGeometry) {
-          (mesh.material as THREE.MeshPhongMaterial).color.set(Colours.getBoxSelected());
-        }
-      }, (mesh: THREE.Mesh) => { /* On mesh deselection */
-        // TEMPORARY - For demonstration purposes
-        if ((mesh as THREE.Mesh).geometry instanceof THREE.BoxGeometry) {
-          (mesh.material as THREE.MeshPhongMaterial).color.set(Colours.getBoxDefault());
-        }
-      }, () => {
-        // TEMPORARY
-        console.log('We have finished projecting the shape into the world');
-      },
-    );
+    this.selectListener = new SelectListener(this.camera, this.scene);
   }
 
   // Public methods:
@@ -199,6 +182,7 @@ export class World {
     // TODO: Do something more maintainable about these function calls
     /* this.shapeSelector.updateSelectedMesh();
      this.shapeSelector.projectMesh();*/
+    this.selectListener.update();
   }
 
   /**


### PR DESCRIPTION
This PR adds the ability for any entity (or anything, for that matter) to listen for selections on a particular mesh. This further decouples our selection logic from the graphics world.

There is an example bit of code in `LiveLoopTemplate` to indicate how we might, with this, listen for fist clenches when someone is looking at a template on the tray.

@chrislomaxjones I used your `selector` as-is to implement this. I understand that there are changes inbound!