### PR TITLE
Add SubscriptionsSet to manage entity subscriptions

### DIFF
--- a/src/Subscriptions.ts
+++ b/src/Subscriptions.ts
@@ -1,0 +1,34 @@
+import THREE = require('three');
+import { Subscription } from 'rxjs';
+import { Entity } from 'src/entities/entity';
+
+/**
+ * Encapsulates a set of subscriptions to things in a world, so that they can all be released in one go
+ */
+export default class Subscriptions {
+  private scene: THREE.Scene;
+  private observableSubscription: Subscription = new Subscription();
+  private threeObjects: THREE.Object3D[] = [];
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+  }
+
+  addThreeObject(object: THREE.Object3D) {
+    this.scene.add(object);
+    this.threeObjects.push(object);
+  }
+
+  addObservableSubscription(subscription: Subscription) {
+    this.observableSubscription.add(subscription);
+  }
+
+  release() {
+    this.observableSubscription.unsubscribe();
+    for (const threeObject of this.threeObjects) {
+      this.scene.remove(threeObject);
+    }
+    this.threeObjects = [];
+    this.observableSubscription = new Subscription();
+  }
+}

--- a/src/SubscriptionsSet.ts
+++ b/src/SubscriptionsSet.ts
@@ -1,0 +1,38 @@
+import THREE = require('three');
+import { Subscription } from 'rxjs';
+
+import { Entity } from 'src/entities/entity';
+import Subscriptions from './Subscriptions';
+
+/**
+ * A mapping of entities to subscriptions.
+ */
+export default class SubscriptionsSet {
+  private entitySubscriptions = new Map<Entity, Subscriptions>();
+  private scene: THREE.Scene;
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+  }
+
+  addObjectForEntity(entity: Entity, object: THREE.Object3D) {
+    this.getEntitySubscriptions(entity).addThreeObject(object);
+  }
+
+  addSubscriptionForEntity(entity: Entity, subscription: Subscription) {
+    this.getEntitySubscriptions(entity).addObservableSubscription(subscription);
+  }
+
+  releaseEntitySubscriptions(entity: Entity) {
+    this.getEntitySubscriptions(entity).release();
+    this.entitySubscriptions.delete(entity);
+  }
+
+  private getEntitySubscriptions(entity: Entity) {
+    if (!this.entitySubscriptions.has(entity)) {
+      this.entitySubscriptions.set(entity, new Subscriptions(this.scene));
+    }
+
+    return this.entitySubscriptions.get(entity)!;
+  }
+}

--- a/src/entities/LiveLoopTemplate.ts
+++ b/src/entities/LiveLoopTemplate.ts
@@ -32,7 +32,6 @@ const liveLoopMaterial = new THREE.MeshPhongMaterial({
  */
 export default class LiveLoopTemplate implements Entity {
   mesh: THREE.Mesh;
-  subscription: Subscription;
   selected: boolean = false;
   definition: LiveLoopTemplateDefinition;
   meshToAdd: THREE.Mesh | null = null;
@@ -51,14 +50,15 @@ export default class LiveLoopTemplate implements Entity {
 
   onAdd(world: World) {
     this.world = world;
-    world.scene.add(this.mesh);
-    this.subscription = new Subscription();
-    this.subscription.add(
+    this.world.addObjectForEntity(this, this.mesh);
+    this.world.addSubscriptionForEntity(
+      this,
       world.selectListener
         .observeSelections(this.mesh)
         .subscribe(event => this.selected = event.selected),
     );
-    this.subscription.add(
+    this.world.addSubscriptionForEntity(
+      this,
       controls.controlEvents
         .filter(controls.eventIs.fist)
         .subscribe(
@@ -93,16 +93,9 @@ export default class LiveLoopTemplate implements Entity {
     }
   }
 
-  onRemove(world: World) {
-    world.scene.remove(this.mesh);
-    this.subscription.unsubscribe();
-    this.finishMeshAdd(false);
-  }
-
   startMeshAdd() {
     this.meshToAdd = this.createMesh();
-    console.log(this.meshToAdd === this.mesh);
-    this.world.scene.add(this.meshToAdd);
+    this.world.addObjectForEntity(this, this.meshToAdd);
   }
 
   finishMeshAdd(addLiveLoop = true) {

--- a/src/entities/entity.ts
+++ b/src/entities/entity.ts
@@ -12,7 +12,7 @@ export interface Entity {
   /**
    * Actions to perform when an entity is removed from a particular world
    */
-  onRemove(world: World): void;
+  onRemove?(world: World): void;
 
   /**
    * If present, is called on every update

--- a/src/world.ts
+++ b/src/world.ts
@@ -7,6 +7,7 @@ import LiveLoopTemplate, { templateDefinitions } from 'src/entities/LiveLoopTemp
 import LiveLoopEntity, { LiveLoopEntityDefinition } from 'src/entities/LiveLoopEntity';
 import TemplateBase from 'src/entities/TemplateBase';
 import { LiveLoopCatagory } from './generation/directory';
+import SubscriptionsSet from './SubscriptionsSet';
 import createReticle from './reticle';
 
 import VrEnvironment from './VrEnvironment';
@@ -23,7 +24,8 @@ export class World {
   readonly camera: THREE.PerspectiveCamera;
   private renderer: THREE.WebGLRenderer;
   private vrEnvironment: VrEnvironment;
-  private entities: Set<Entity> = new Set();
+  private subscriptionsSet: SubscriptionsSet;
+  private entities = new Set<Entity>();
 
   /**
    * Lights associated with the world.
@@ -37,6 +39,7 @@ export class World {
   constructor() {
     // Basic set up of scene, camera, and renderer:
     this.scene = new THREE.Scene();
+    this.subscriptionsSet = new SubscriptionsSet(this.scene);
 
     // NOTE: arguments to perspective camera are:
     // Field of view, aspect ratio, near and far clipping plane
@@ -85,11 +88,28 @@ export class World {
     }
 
     this.entities.delete(entity);
-    entity.onRemove(this);
+    if (entity.onRemove) {
+      entity.onRemove(this);
+    }
+    this.subscriptionsSet.releaseEntitySubscriptions(entity);
   }
 
   hasEntity(entity: Entity) {
     return this.entities.has(entity);
+  }
+
+  /**
+   * Adds a threejs object to the world that will be removed when this entity is
+   */
+  addObjectForEntity: SubscriptionsSet['addObjectForEntity'] = (entity, object) => {
+    this.subscriptionsSet.addObjectForEntity(entity, object);
+  }
+
+  /**
+   * Adds an observable subscription to the world that will be removed when the entity is
+   */
+  addSubscriptionForEntity: SubscriptionsSet['addSubscriptionForEntity'] = (entity, subscription) => {
+    this.subscriptionsSet.addSubscriptionForEntity(entity, subscription);
   }
 
   /**


### PR DESCRIPTION
We're repeating a lot of teardown code for entities. This PR adds the ability for entities to collect all of their subscriptions together and then have them be automatically removed.