### PR TITLE
Improve live loop selection

### DIFF
--- a/src/SelectListener.ts
+++ b/src/SelectListener.ts
@@ -13,46 +13,46 @@ interface DeselectionEvent {
 type SelectListenerEvent = SelectionEvent | DeselectionEvent;
 
 /**
- * Listens for selection of meshes activated by the camera looking at a mesh.
+ * Listens for selection of objectes activated by the camera looking at a object.
  */
 export default class SelectListener {
   selector: Selector;
-  meshesToSubjects: WeakMap<THREE.Mesh, Subject<SelectListenerEvent>> = new WeakMap();
+  objectsToSubjects: WeakMap<THREE.Object3D, Subject<SelectListenerEvent>> = new WeakMap();
 
   constructor(camera: THREE.Camera, scene: THREE.Scene) {
     this.selector = new Selector(
       camera,
       scene,
-      mesh => this.onSelect(mesh),
-      mesh => this.onDeselect(mesh),
+      object => this.onSelect(object),
+      object => this.onDeselect(object),
     );
   }
 
-  observeSelections(mesh: THREE.Mesh) {
-    return this.getMeshSubject(mesh).asObservable();
+  observeSelections(object: THREE.Object3D) {
+    return this.getObjectSubject(object).asObservable();
   }
 
-  getMeshSubject(mesh: THREE.Mesh) {
-    if (!this.meshesToSubjects.has(mesh)) {
-      this.meshesToSubjects.set(mesh, new Subject());
+  getObjectSubject(object: THREE.Object3D) {
+    if (!this.objectsToSubjects.has(object)) {
+      this.objectsToSubjects.set(object, new Subject());
     }
 
-    return this.meshesToSubjects.get(mesh)!;
+    return this.objectsToSubjects.get(object)!;
   }
 
-  onSelect(mesh: THREE.Mesh) {
-    this.getMeshSubject(mesh).next({
+  onSelect(object: THREE.Object3D) {
+    this.getObjectSubject(object).next({
       selected: true,
     });
   }
 
-  onDeselect(mesh: THREE.Mesh) {
-    this.getMeshSubject(mesh).next({
+  onDeselect(object: THREE.Object3D) {
+    this.getObjectSubject(object).next({
       selected: false,
     });
   }
 
   update() {
-    this.selector.updateSelectedMesh();
+    this.selector.updateSelectedObject();
   }
 }

--- a/src/Subscriptions.ts
+++ b/src/Subscriptions.ts
@@ -1,6 +1,7 @@
 import THREE = require('three');
 import { Subscription } from 'rxjs';
 import { Entity } from 'src/entities/entity';
+import { Selector } from 'src/selector';
 
 /**
  * Encapsulates a set of subscriptions to things in a world, so that they can all be released in one go
@@ -9,9 +10,12 @@ export default class Subscriptions {
   private scene: THREE.Scene;
   private observableSubscription: Subscription = new Subscription();
   private threeObjects: THREE.Object3D[] = [];
+  private selectableObjects: THREE.Object3D[] = [];
+  private selector: Selector;
 
-  constructor(scene: THREE.Scene) {
+  constructor(scene: THREE.Scene, selector: Selector) {
     this.scene = scene;
+    this.selector = selector;
   }
 
   addThreeObject(object: THREE.Object3D) {
@@ -23,12 +27,21 @@ export default class Subscriptions {
     this.observableSubscription.add(subscription);
   }
 
+  addSelectorObject(object: THREE.Object3D) {
+    this.selector.checkForObject(object);
+    this.selectableObjects.push(object);
+  }
+
   release() {
     this.observableSubscription.unsubscribe();
     for (const threeObject of this.threeObjects) {
       this.scene.remove(threeObject);
     }
+    for (const selectableObject of this.selectableObjects) {
+      this.selector.stopCheckingForObject(selectableObject);
+    }
     this.threeObjects = [];
+    this.selectableObjects = [];
     this.observableSubscription = new Subscription();
   }
 }

--- a/src/SubscriptionsSet.ts
+++ b/src/SubscriptionsSet.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Entity } from 'src/entities/entity';
 import Subscriptions from './Subscriptions';
+import { Selector } from 'src/selector';
 
 /**
  * A mapping of entities to subscriptions.
@@ -10,9 +11,11 @@ import Subscriptions from './Subscriptions';
 export default class SubscriptionsSet {
   private entitySubscriptions = new Map<Entity, Subscriptions>();
   private scene: THREE.Scene;
+  private selector: Selector;
 
-  constructor(scene: THREE.Scene) {
+  constructor(scene: THREE.Scene, selector: Selector) {
     this.scene = scene;
+    this.selector = selector;
   }
 
   addObjectForEntity(entity: Entity, object: THREE.Object3D) {
@@ -23,6 +26,10 @@ export default class SubscriptionsSet {
     this.getEntitySubscriptions(entity).addObservableSubscription(subscription);
   }
 
+  addSelectorObject(entity: Entity, object: THREE.Object3D) {
+    this.getEntitySubscriptions(entity).addSelectorObject(object);
+  }
+
   releaseEntitySubscriptions(entity: Entity) {
     this.getEntitySubscriptions(entity).release();
     this.entitySubscriptions.delete(entity);
@@ -30,7 +37,7 @@ export default class SubscriptionsSet {
 
   private getEntitySubscriptions(entity: Entity) {
     if (!this.entitySubscriptions.has(entity)) {
-      this.entitySubscriptions.set(entity, new Subscriptions(this.scene));
+      this.entitySubscriptions.set(entity, new Subscriptions(this.scene, this.selector));
     }
 
     return this.entitySubscriptions.get(entity)!;

--- a/src/entities/LiveLoopEntity.ts
+++ b/src/entities/LiveLoopEntity.ts
@@ -32,6 +32,7 @@ export default class LiveLoopEntity implements Entity {
 
   onAdd(world: World) {
     world.addObjectForEntity(this, this.mesh);
+    world.addSelectorObject(this, this.mesh);
     this.liveloop = new LiveLoop(this.type);
     world.addSubscriptionForEntity(
       this,

--- a/src/entities/LiveLoopTemplate.ts
+++ b/src/entities/LiveLoopTemplate.ts
@@ -51,6 +51,7 @@ export default class LiveLoopTemplate implements Entity {
   onAdd(world: World) {
     this.world = world;
     this.world.addObjectForEntity(this, this.mesh);
+    this.world.addSelectorObject(this, this.mesh);
     this.world.addSubscriptionForEntity(
       this,
       world.selectListener

--- a/src/entities/LiveLoopTemplate.ts
+++ b/src/entities/LiveLoopTemplate.ts
@@ -28,6 +28,18 @@ function createLiveLoopMaterial(color: number, opacity: number) {
   });
 }
 
+function createBase() {
+  const base = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.2, 0.2, 0.05, 20),
+    new THREE.MeshLambertMaterial({
+      color: 0x444444,
+    }),
+  );
+  base.position.setY(-1.2);
+
+  return base;
+}
+
 /**
  * A LiveLoopTemplate can be selected by the user to create a new live loop
  * in the world.
@@ -42,26 +54,19 @@ export default class LiveLoopTemplate implements Entity {
 
   constructor(definition: LiveLoopTemplateDefinition) {
     this.definition = definition;
-    this.mesh = this.createMesh(0x333333, 1);
-    this.group = new THREE.Group();
-    const base = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.2, 0.2, 0.05, 20),
-      new THREE.MeshLambertMaterial({
-        color: 0x444444,
-      }),
-    );
-    base.position.setY(-1.2);
-    this.group.add(this.mesh);
-    this.group.add(base);
 
+    this.group = new THREE.Group();
+
+    this.mesh = this.createMesh(0x333333, 1);
     this.mesh.position.setY(-0.7);
+    this.mesh.scale.set(0.5, 0.5, 0.5);
+    this.group.add(this.mesh);
+    this.group.add(createBase());
     this.group.position.set(
       definition.position.x,
       0,
       definition.position.z,
     );
-
-    this.mesh.scale.set(0.5, 0.5, 0.5);
   }
 
   onAdd(world: World) {
@@ -88,7 +93,6 @@ export default class LiveLoopTemplate implements Entity {
         .subscribe(
           controls.listenPose({
             start: () => {
-              console.log('fist');
               if (this.selected) {
                 this.startMeshAdd();
 

--- a/src/entities/TemplateBase.ts
+++ b/src/entities/TemplateBase.ts
@@ -10,10 +10,10 @@ export default class TemplateBase implements Entity {
 
   onAdd(world: World) {
     this.mesh = new THREE.Mesh(
-      new THREE.CylinderGeometry(10, 10, 0.5, 32, 32),
-      new THREE.MeshPhongMaterial({ color: 0xffffff, opacity: 0.2, transparent: true }),
+      new THREE.CylinderGeometry(6, 6, 0.5, 32, 32),
+      new THREE.MeshPhongMaterial({ color: 0x333333 }),
     );
-    this.mesh.position.set(0, -5, 0);
+    this.mesh.position.set(0, -4, 0);
     world.scene.add(this.mesh);
   }
 

--- a/src/reticle.ts
+++ b/src/reticle.ts
@@ -13,7 +13,6 @@ export default function createReticle() {
         color: 0xffffff,
         opacity: 0.7,
         transparent: true,
-        depthTest: false,
       }),
     ),
   );
@@ -25,7 +24,6 @@ export default function createReticle() {
         color: 0x111111,
         opacity: 1,
         transparent: true,
-        depthTest: false,
       }),
     ),
   );

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -11,33 +11,28 @@ export class Selector {
 
   // Represents the currently selected mesh
   // Note may be undefined (i.e. no mesh selected)
-  private selectedMesh? : THREE.Mesh;
+  private selectedObject? : THREE.Object3D;
 
   // Functions for callbacks on mesh selection and deselection
-  selectMesh : (mesh : THREE.Mesh) => void;
-  deselectMesh : (mesh : THREE.Mesh) => void;
+  selectObject: (object: THREE.Object3D) => void;
+  deselectObject: (object: THREE.Object3D) => void;
 
   // Functions for callbacks on fist gestures
-  onFistStart: (mesh : THREE.Mesh) => void;
-  onFistEnd: (mesh : THREE.Mesh) => void;
+  onFistStart: (object: THREE.Object3D) => void;
+  onFistEnd: (object: THREE.Object3D) => void;
 
   // Functions for callbacks on wave gestures
-  onWaveInStart: (mesh : THREE.Mesh) => void;
-  onWaveInEnd: (mesh : THREE.Mesh) => void;
+  onWaveInStart: (object: THREE.Object3D) => void;
+  onWaveInEnd: (object: THREE.Object3D) => void;
 
-  onWaveOutStart: (mesh : THREE.Mesh) => void;
-  onWaveOutEnd: (mesh : THREE.Mesh) => void;
+  onWaveOutStart: (object: THREE.Object3D) => void;
+  onWaveOutEnd: (object: THREE.Object3D) => void;
 
   // Functions for callbacks on spread gesture
-  onSpreadStart: (mesh : THREE.Mesh) => void;
-  onSpreadEnd: (mesh : THREE.Mesh) => void;
+  onSpreadStart: (object: THREE.Object3D) => void;
+  onSpreadEnd: (object: THREE.Object3D) => void;
 
-  // Properties regarding moving and projecting the mesh
-  private isMoving = false;
-  private isProjecting = false;
-  private projectingMesh? : THREE.Mesh;
-  private projectionDirection = new THREE.Vector3(0, 0, 0);
-  private movingMesh? : THREE.Mesh;
+  private objectsToCheck: THREE.Object3D[] = [];
 
   // Public methods
 
@@ -47,23 +42,23 @@ export class Selector {
    */
   constructor(camera: THREE.Camera,
               scene: THREE.Scene,
-              onMeshSelected: (mesh: THREE.Mesh) => void = voidFunction,
-              onMeshDeselected: (mesh: THREE.Mesh) => void = voidFunction,
-              onFistStart: (mesh: THREE.Mesh) => void = voidFunction,
-              onFistEnd: (mesh: THREE.Mesh) => void = voidFunction,
-              onWaveInStart: (mesh: THREE.Mesh) => void = voidFunction,
-              onWaveInEnd: (mesh: THREE.Mesh) => void = voidFunction,
-              onWaveOutStart: (mesh: THREE.Mesh) => void = voidFunction,
-              onWaveOutEnd: (mesh: THREE.Mesh) => void = voidFunction,
-              onSpreadStart: (mesh: THREE.Mesh) => void = voidFunction,
-              onSpreadEnd: (mesh: THREE.Mesh) => void = voidFunction) {
+              onObjectSelected: (mesh: THREE.Object3D) => void = voidFunction,
+              onObjectDeselected: (mesh: THREE.Object3D) => void = voidFunction,
+              onFistStart: (mesh: THREE.Object3D) => void = voidFunction,
+              onFistEnd: (mesh: THREE.Object3D) => void = voidFunction,
+              onWaveInStart: (mesh: THREE.Object3D) => void = voidFunction,
+              onWaveInEnd: (mesh: THREE.Object3D) => void = voidFunction,
+              onWaveOutStart: (mesh: THREE.Object3D) => void = voidFunction,
+              onWaveOutEnd: (mesh: THREE.Object3D) => void = voidFunction,
+              onSpreadStart: (mesh: THREE.Object3D) => void = voidFunction,
+              onSpreadEnd: (mesh: THREE.Object3D) => void = voidFunction) {
     this.camera = camera;
     this.scene = scene;
 
     this.rayCaster = new THREE.Raycaster();
 
-    this.selectMesh = onMeshSelected;
-    this.deselectMesh = onMeshDeselected;
+    this.selectObject = onObjectSelected;
+    this.deselectObject = onObjectDeselected;
 
     // Initialize callback functions for gestures
     this.onFistStart = onFistStart;
@@ -81,14 +76,14 @@ export class Selector {
       .subscribe(controls.listenPose({
         start: () => {
           // Check we have selected a mesh first
-          if (this.selectedMesh) {
-            this.onFistStart(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onFistStart(this.selectedObject);
           }
         },
         finish: () => {
           // Check we have selected a mesh first
-          if (this.selectedMesh) {
-            this.onFistEnd(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onFistEnd(this.selectedObject);
           }
         },
       }));
@@ -98,14 +93,14 @@ export class Selector {
       .subscribe(controls.listenPose({
         start: () => {
           // Check we have selected a mesh
-          if (this.selectedMesh) {
-            this.onWaveInStart(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onWaveInStart(this.selectedObject);
           }
         },
         finish: () => {
           // Check we have selected a mesh first
-          if (this.selectedMesh) {
-            this.onWaveInEnd(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onWaveInEnd(this.selectedObject);
           }
         },
       }));
@@ -115,14 +110,14 @@ export class Selector {
       .subscribe(controls.listenPose({
         start: () => {
           // Check we have selected a mesh
-          if (this.selectedMesh) {
-            this.onWaveOutStart(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onWaveOutStart(this.selectedObject);
           }
         },
         finish: () => {
           // Check we have selected a mesh first
-          if (this.selectedMesh) {
-            this.onWaveOutEnd(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onWaveOutEnd(this.selectedObject);
           }
         },
       }));
@@ -132,35 +127,49 @@ export class Selector {
       .subscribe(controls.listenPose({
         start: () => {
           // Check we have selected a mesh
-          if (this.selectedMesh) {
-            this.onSpreadStart(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onSpreadStart(this.selectedObject);
           }
         },
         finish: () => {
           // Check we have selected a mesh first
-          if (this.selectedMesh) {
-            this.onSpreadEnd(this.selectedMesh);
+          if (this.selectedObject) {
+            this.onSpreadEnd(this.selectedObject);
           }
         },
       }));
   }
 
+  checkForObject(object: THREE.Object3D) {
+    if (!this.objectsToCheck.includes(object)) {
+      this.objectsToCheck.push(object);
+    }
+  }
+
+  stopCheckingForObject(object: THREE.Object3D) {
+    const objectIndex = this.objectsToCheck.indexOf(object);
+
+    if (objectIndex !== -1) {
+      this.objectsToCheck.splice(objectIndex, 1);
+    }
+  }
+
   /**
-   * Returns the currently selected Mesh
+   * Returns the currently selected Object3D
    */
   getSelectedMesh() {
-    return this.selectedMesh;
+    return this.selectedObject;
   }
 
   setSelectedMesh(mesh : THREE.Mesh) {
-    this.selectedMesh = mesh;
+    this.selectedObject = mesh;
   }
   /**
-    * Method returns the mesh hit by a raycast
-    * Provided with a bool to check whether any mesh
+    * Method returns the Object3D hit by a raycast
+    * Provided with a bool to check whether any Object3D
     * was hit at all
   */
-  updateSelectedMesh() {
+  updateSelectedObject() {
     // Update picking ray with camera and position
     // Position (0,0) casts ray from centre of screen
     // This seems to work fine for now
@@ -170,31 +179,27 @@ export class Selector {
     );
 
     // Get array of intersected objects
-    const intersects = this.rayCaster.intersectObjects(this.scene.children);
+    const intersects = this.rayCaster.intersectObjects(this.objectsToCheck);
 
-    // Check if raycaster intersects with a mesh
-    if (intersects[0] && intersects[0].object instanceof THREE.Mesh) {
-      if (this.selectedMesh) {
-        // Check if the mesh is not the one already selected
-        if (intersects[0].object as THREE.Mesh !== this.selectedMesh) {
-          // Deselect the mesh and update the selected mesh to the new one
-          this.deselectMesh(this.selectedMesh);
-          this.selectedMesh = intersects[0].object as THREE.Mesh;
-          this.selectMesh(this.selectedMesh);
+    // Check if raycaster intersects
+    if (intersects[0]) {
+      if (this.selectedObject) {
+        // Check if the Object3D is not the one already selected
+        if (intersects[0].object !== this.selectedObject) {
+          // Deselect the Object3D and update the selected Object3D to the new one
+          this.deselectObject(this.selectedObject);
+          this.selectedObject = intersects[0].object;
+          this.selectObject(this.selectedObject);
         }
       } else {
-        this.selectedMesh = intersects[0].object as THREE.Mesh;
-        this.selectMesh(this.selectedMesh);
+        this.selectedObject = intersects[0].object;
+        this.selectObject(this.selectedObject);
       }
-    } else { // No intersection with a mesh
-      if (this.selectedMesh !== undefined) {
-        this.deselectMesh(this.selectedMesh);
-        this.selectedMesh = undefined;
+    } else { // No intersection with a Object3D
+      if (this.selectedObject !== undefined) {
+        this.deselectObject(this.selectedObject);
+        this.selectedObject = undefined;
       }
     }
-  }
-
-  update(delta: number) {
-    this.updateSelectedMesh();
   }
 }

--- a/src/world.ts
+++ b/src/world.ts
@@ -39,7 +39,6 @@ export class World {
   constructor() {
     // Basic set up of scene, camera, and renderer:
     this.scene = new THREE.Scene();
-    this.subscriptionsSet = new SubscriptionsSet(this.scene);
 
     // NOTE: arguments to perspective camera are:
     // Field of view, aspect ratio, near and far clipping plane
@@ -59,6 +58,7 @@ export class World {
 
     // Set up the Selector by passing it the scene and camera
     this.selectListener = new SelectListener(this.camera, this.scene);
+    this.subscriptionsSet = new SubscriptionsSet(this.scene, this.selectListener.selector);
   }
 
   // Public methods:
@@ -110,6 +110,13 @@ export class World {
    */
   addSubscriptionForEntity: SubscriptionsSet['addSubscriptionForEntity'] = (entity, subscription) => {
     this.subscriptionsSet.addSubscriptionForEntity(entity, subscription);
+  }
+
+  /**
+   * Adds an object to be checked for selections that will stop checking when the entity is removed
+   */
+  addSelectorObject: SubscriptionsSet['addSelectorObject'] = (entity, object) => {
+    this.subscriptionsSet.addSelectorObject(entity, object);
   }
 
   /**

--- a/src/world.ts
+++ b/src/world.ts
@@ -43,7 +43,7 @@ export class World {
     // NOTE: arguments to perspective camera are:
     // Field of view, aspect ratio, near and far clipping plane
     this.camera = new THREE.PerspectiveCamera(
-      75,
+      70,
       window.innerWidth / window.innerHeight,
       0.1, 1000,
     );
@@ -128,8 +128,8 @@ export class World {
 
     // Add a wireframe grid helper to the scene:
     // (for debug purposes)
-    const gridHelper = new THREE.GridHelper(150, 150);
-    gridHelper.position.set(0, -2, 0);
+    const gridHelper = new THREE.GridHelper(200, 150);
+    gridHelper.position.set(0, -4, 0);
     this.scene.add(gridHelper);
 
     // Add ambient light:


### PR DESCRIPTION
Depends on #52 

This PR tries to aid with spatial awareness and make the selection process of live loops a little nicer. To do this, we've added bases to individual live loops, tweaked the tray and grid, and now the live loops grow when you hover over them.

![image](https://cloud.githubusercontent.com/assets/3238878/23533394/73c4ebe0-ffa9-11e6-835b-0c9124ee99e3.png)
