### PR TITLE
Improve visualisation

### DIFF
--- a/src/entities/LiveLoopTemplate.ts
+++ b/src/entities/LiveLoopTemplate.ts
@@ -113,7 +113,7 @@ export default class LiveLoopTemplate implements Entity {
 
   onUpdate(delta: number) {
     if (this.meshToAdd) {
-      utils.projectMeshDistanceFromCamera(
+      utils.projectObjectDistanceFromCamera(
         this.world.camera,
         this.meshToAdd,
         3,

--- a/src/entities/utils.ts
+++ b/src/entities/utils.ts
@@ -1,8 +1,8 @@
 import THREE = require('three');
 
-export function projectMeshDistanceFromCamera(camera: THREE.Camera, mesh: THREE.Mesh, distance: number) {
+export function projectObjectDistanceFromCamera(camera: THREE.Camera, object: THREE.Object3D, distance: number) {
   const newPos = camera.position.add(camera.getWorldDirection().multiplyScalar(distance));
-  mesh.position.set(
+  object.position.set(
     newPos.x,
     newPos.y,
     newPos.z,
@@ -13,8 +13,8 @@ export function setVectorFromVector(to: THREE.Vector3, from: THREE.Vector3) {
   to.set(from.x, from.y, from.z);
 }
 
-export function moveMeshUp(delta : number, scale : number, mesh : THREE.Mesh) {
-  mesh.position.add(
+export function moveObjectUp(delta : number, scale : number, object : THREE.Object3D) {
+  object.position.add(
     new THREE.Vector3(
       0,
       delta * scale,

--- a/src/world.ts
+++ b/src/world.ts
@@ -28,6 +28,7 @@ export class World {
   private vrEnvironment: VrEnvironment;
   private subscriptionsSet: SubscriptionsSet;
   private entities = new Set<Entity>();
+  private prevTimestamp: number = 0;
 
   /**
    * Lights associated with the world.
@@ -155,7 +156,9 @@ export class World {
   /**
    * Update the objects in the world
    */
-  update(delta: number) {
+  update(timestamp: number) {
+    const delta = timestamp - this.prevTimestamp;
+    this.prevTimestamp = timestamp;
     this.selectListener.update();
     for (const entity of this.entities) {
       if (entity.onUpdate) {


### PR DESCRIPTION
We now have a sensible minimum size for live loops, and the visualisation is represented with a "shell" around them

![image](https://cloud.githubusercontent.com/assets/3238878/23551688/dacf4b08-000f-11e7-9e9b-bd372727aa77.png)
