### PR TITLE
Add volume display for live loops

### DIFF
--- a/src/generation/LiveLoop.ts
+++ b/src/generation/LiveLoop.ts
@@ -57,6 +57,12 @@ export default class LiveLoop {
     } else {
       this.volume = v;
     }
+
+    this.generateAndPushRuby();
+  }
+
+  public getVolume() {
+    return this.volume;
   }
 
   public nextEffect() {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3238878/23578727/48d1ae50-00d5-11e7-93c4-64e95e5b1a1d.png)

This PR adds a small indicator for LiveLoop volume when they are selected. This does not implement any way of changing them.